### PR TITLE
Local density speed up 3

### DIFF
--- a/tbk_qgis/tbk/postproc/tbk_qgis_postprocess_local_density.py
+++ b/tbk_qgis/tbk/postproc/tbk_qgis_postprocess_local_density.py
@@ -594,13 +594,16 @@ class TBkPostprocessLocalDensity(QgsProcessingAlgorithm):
         # merge listed layers with density polygons of different classes
         feedback.pushInfo("merge local densities of all classes ...")
         param = {'LAYERS': den_polys, 'CRS': None, 'OUTPUT': 'TEMPORARY_OUTPUT'}
-        # 'TEMPORARY_OUTPUT' does work as output! --> all off a sudden all listed layers are merged (unclear which code
-        # manipulation(s) enable this) --> temp. .gpkg as output / workaround not needed any more!
-        # path_tmp_den_polys = os.path.join(path_output, "tmp_den_polys.gpkg") # hopefully no future need for this ...
-        # param =  {'LAYERS': den_polys, 'CRS': None, 'OUTPUT': path_tmp_den_polys} # ... since deleting tmp. .gpkg is an unsolved issue
         algoOutput = processing.run("native:mergevectorlayers", param)
         den_polys = algoOutput["OUTPUT"]
-        # f_save_as_gpkg(den_polys, "den_polys_polygonized")
+
+        # overwrite fid of merged density polygons with unique values ...
+        param ={'INPUT': den_polys, 'FIELD_NAME': 'fid', 'FIELD_TYPE': 1, 'FIELD_LENGTH': 0, 'FIELD_PRECISION': 0,
+                'FORMULA': 'id', 'OUTPUT': 'TEMPORARY_OUTPUT'}
+        algoOutput = processing.run("native:fieldcalculator", param)
+        den_polys = algoOutput["OUTPUT"]
+        # f_save_as_gpkg(den_polys, "den_polys_polygonized") # ... in order make them exportable without complain and not ...
+                                                             # ... just those features inherited form the 1st element of above merged list
 
         # remove holes smaller than threshold
         if holes_thresh > 0:


### PR DESCRIPTION
This is the continuation of pull request https://github.com/HAFL-WWI/TBk/pull/66. That pull didn’t solved the problem of local densities’ run time increasing exponentially with the amount of input data (= output of _**Generate BK**_). Due to this processing of local densities for the whole Canton VD (137’000 TBk-stand-geometries) would have taken ages (after some days we stopped the procedure). Two bottlenecks caused the exponentially increasing run time:

* the intersection of stands (input geometries) and the internally generated local density geometries.
* calculation of local density metrics per stand and joining these values to the TBk-stand-map’s attribute table.

By redesigning these two algorithm parts such that they handle the data in an iterative / portion-wise manner the run time seems now to behave somewhat more linear to the amount of input. Other related and lately discovered issues have been fixed. For details read commit messages.

Experiences made so far with the fixed local densities’ algorithm show that run times are reasonable:

* 4:22 h for 137’000 input geometries / 110’000 ha (Canton VD) locally on a Windows PC
* 1.10 h for 91’000 input geometries / 46’000 ha (Canton FR) locally on a Windows PC
* 2.08 h for 91’000 input geometries / 46’000 ha (Canton FR) on HARA04
* 9:55 h for 285'000 input geometries / 206'000 ha (Canton GR) on HARA04

Final remark: In general, for future development of TBk we have to keep in mind that what works with a small amount of test data might fail when applied to larger input volumes. So, at some late development stage we should check with larger quantities. Doing so may prevent unpleasant surprises and stress.
 